### PR TITLE
Detect host url from conn struct and derive google_redirect_uri issue #17

### DIFF
--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -8,17 +8,31 @@ defmodule ElixirAuthGoogle do
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"
 
+
+  @doc """
+  `get_baseurl_from_conn/1` derives the base URL from the conn struct
+  """
+  @spec get_baseurl_from_conn(Map) :: String.t
+  def get_baseurl_from_conn(conn) do
+    if conn.host == "localhost" do
+      "http://" <> conn.host <> ":" <> to_string(conn.port)
+    else
+      "https://" <> conn.host
+    end
+  end
+
   @doc """
   `generate_oauth_url/0` creates the Google OAuth2 URL with client_id, scope and
   redirect_uri which is the URL Google will redirect to when auth is successful.
   This is the URL you need to use for your "Login with Google" button.
   See step 5 of the instructions.
   """
-  @spec generate_oauth_url :: String.t
-  def generate_oauth_url do
+  @spec generate_oauth_url(Map) :: String.t
+  def generate_oauth_url(conn) do
     client_id = Application.get_env(:elixir_auth_google, :google_client_id)
     scope = Application.get_env(:elixir_auth_google, :google_scope ) || "profile"
-    redirect_uri = Application.get_env(:elixir_auth_google, :google_redirect_uri)
+    redirect_uri = get_baseurl_from_conn(conn) <> "/auth/google/callback"
+    # Application.get_env(:elixir_auth_google, :google_redirect_uri)
 
     "#{@google_auth_url}&client_id=#{client_id}&scope=#{scope}&redirect_uri=#{redirect_uri}"
   end

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -13,7 +13,13 @@ defmodule ElixirAuthGoogle do
   `get_baseurl_from_conn/1` derives the base URL from the conn struct
   """
   @spec get_baseurl_from_conn(Map) :: String.t
-  def get_baseurl_from_conn(conn) do
+  def get_baseurl_from_conn(%{host: h, port: p}) when host == "localhost" do
+    "http://#{h}:#{p}"
+  end
+  
+  def get_baseurl_from_conn(%{host: h}) do
+     "https://#{h}"
+  end
     if conn.host == "localhost" do
       "http://" <> conn.host <> ":" <> to_string(conn.port)
     else

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -13,19 +13,14 @@ defmodule ElixirAuthGoogle do
   `get_baseurl_from_conn/1` derives the base URL from the conn struct
   """
   @spec get_baseurl_from_conn(Map) :: String.t
-  def get_baseurl_from_conn(%{host: h, port: p}) when host == "localhost" do
+  def get_baseurl_from_conn(%{host: h, port: p}) when h == "localhost" do
     "http://#{h}:#{p}"
   end
   
   def get_baseurl_from_conn(%{host: h}) do
      "https://#{h}"
   end
-    if conn.host == "localhost" do
-      "http://" <> conn.host <> ":" <> to_string(conn.port)
-    else
-      "https://" <> conn.host
-    end
-  end
+
 
   @doc """
   `generate_redirect_uri/1` generates the Google redirect uri based on conn

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -40,7 +40,6 @@ defmodule ElixirAuthGoogle do
     client_id = Application.get_env(:elixir_auth_google, :google_client_id)
     scope = Application.get_env(:elixir_auth_google, :google_scope ) || "profile"
     redirect_uri = generate_redirect_uri(conn)
-    # Application.get_env(:elixir_auth_google, :google_redirect_uri)
 
     "#{@google_auth_url}&client_id=#{client_id}&scope=#{scope}&redirect_uri=#{redirect_uri}"
   end

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -22,6 +22,14 @@ defmodule ElixirAuthGoogle do
   end
 
   @doc """
+  `generate_redirect_uri/1` generates the Google redirect uri based on conn
+  """
+  @spec generate_redirect_uri(Map) :: String.t
+  def generate_redirect_uri(conn) do
+    get_baseurl_from_conn(conn) <> "/auth/google/callback"
+  end
+
+  @doc """
   `generate_oauth_url/0` creates the Google OAuth2 URL with client_id, scope and
   redirect_uri which is the URL Google will redirect to when auth is successful.
   This is the URL you need to use for your "Login with Google" button.
@@ -31,24 +39,24 @@ defmodule ElixirAuthGoogle do
   def generate_oauth_url(conn) do
     client_id = Application.get_env(:elixir_auth_google, :google_client_id)
     scope = Application.get_env(:elixir_auth_google, :google_scope ) || "profile"
-    redirect_uri = get_baseurl_from_conn(conn) <> "/auth/google/callback"
+    redirect_uri = generate_redirect_uri(conn)
     # Application.get_env(:elixir_auth_google, :google_redirect_uri)
 
     "#{@google_auth_url}&client_id=#{client_id}&scope=#{scope}&redirect_uri=#{redirect_uri}"
   end
 
   @doc """
-  `get_token/1` encodes the secret keys and authorization code returned by Google
+  `get_token/2` encodes the secret keys and authorization code returned by Google
   and issues an HTTP request to get a person's profile data.
 
   **TODO**: we still need to handle the various failure conditions >> issues/16
   """
-  @spec get_token(String.t) :: String.t
-  def get_token(code) do
+  @spec get_token(String.t, Map) :: String.t
+  def get_token(code, conn) do
     body = Poison.encode!(
       %{ client_id: Application.get_env(:elixir_auth_google, :google_client_id),
          client_secret: Application.get_env(:elixir_auth_google, :google_client_secret),
-         redirect_uri: Application.get_env(:elixir_auth_google, :google_redirect_uri),
+         redirect_uri: generate_redirect_uri(conn),
          grant_type: "authorization_code",
          code: code
     })

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "0.0.1"
+  @version "0.1.0"
 
   def project do
     [

--- a/test/elixir_auth_google_test.exs
+++ b/test/elixir_auth_google_test.exs
@@ -1,10 +1,33 @@
 defmodule ElixirAuthGoogleTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+  # use Plug.Test
   doctest ElixirAuthGoogle
+
+
+  test "get_baseurl_from_conn(conn) detects the URL based on conn.host" do
+    conn = %{
+      host: "localhost",
+      port: 4000
+    }
+    assert ElixirAuthGoogle.get_baseurl_from_conn(conn) == "http://localhost:4000"
+  end
+
+
+  test "get_baseurl_from_conn(conn) detects the URL for production" do
+    conn = %{
+      host: "dwyl.com",
+      port: 80
+    }
+    assert ElixirAuthGoogle.get_baseurl_from_conn(conn) == "https://dwyl.com"
+  end
 
   test "get Google login url" do
     Application.put_env(:elixir_auth_google, :google_client_id, 123)
-    assert ElixirAuthGoogle.generate_oauth_url() =~ "https://accounts.google.com/o/oauth2/v2/auth?response_type=code"
+    conn = %{
+      host: "localhost",
+      port: 4000
+    }
+    assert ElixirAuthGoogle.generate_oauth_url(conn) =~ "https://accounts.google.com/o/oauth2/v2/auth?response_type=code"
   end
 
   test "get Google token" do

--- a/test/elixir_auth_google_test.exs
+++ b/test/elixir_auth_google_test.exs
@@ -31,7 +31,11 @@ defmodule ElixirAuthGoogleTest do
   end
 
   test "get Google token" do
-    assert ElixirAuthGoogle.get_token("ok_code") == {:ok, %{"access_token" => "token1"}}
+        conn = %{
+      host: "localhost",
+      port: 4000
+    }
+    assert ElixirAuthGoogle.get_token("ok_code", conn) == {:ok, %{"access_token" => "token1"}}
   end
 
   test "get user profile" do


### PR DESCRIPTION
Hi @SimonLab as described in #17 the objective of this PR is to:
+ [x] reduce steps in configuring the _consuming_ app (using this package) by detecting the `google_redirect_uri` from the `conn` struct.