### PR TITLE
Add sensible defaults to the project config.exs 

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,3 +3,9 @@ use Mix.Config
 if Mix.env() == :test do
   config :elixir_auth_google, httpoison: ElixirAuthGoogle.HTTPoison.InMemory
 end
+
+# Google application configuration
+config :elixir_auth_google,
+  google_client_id: System.get_env("GOOGLE_CLIENT_ID"),
+  google_client_secret: System.get_env("GOOGLE_CLIENT_SECRET"),
+  google_scope: "profile email"


### PR DESCRIPTION
to avoid forcing people using the package to have to add the default to their project config.exs 
+ [x] fixes https://github.com/dwyl/elixir-auth-google/issues/19