### PR TITLE
Transform map keys to atoms issue #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The _easiest_ way to add Google OAuth authentication to your Elixir Apps.
 
 ![sign-in-with-google-buttons](https://user-images.githubusercontent.com/194400/69637172-07a67900-1050-11ea-9e25-2b9e84a49d91.png)
 
-[![Build Status](https://img.shields.io/travis/dwyl/elixir-auth-google/master.svg?style=flat-square)](https://travis-ci.org/dwyl/elixir-auth-google)
+![Build Status](https://img.shields.io/travis/com/dwyl/elixir-auth-google/master?color=bright-green&style=flat-square)
 [![codecov.io](https://img.shields.io/codecov/c/github/dwyl/elixir-auth-google/master.svg?style=flat-square)](http://codecov.io/github/dwyl/elixir-auth-google?branch=master)
 ![Hex.pm](https://img.shields.io/hexpm/v/elixir_auth_google?color=brightgreen&style=flat-square)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/elixir-auth-google/issues)

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,3 +3,9 @@ use Mix.Config
 if Mix.env() == :test do
   config :elixir_auth_google, httpoison: ElixirAuthGoogle.HTTPoison.InMemory
 end
+
+# Google application configuration
+config :elixir_auth_google,
+  google_client_id: System.get_env("GOOGLE_CLIENT_ID"),
+  google_client_secret: System.get_env("GOOGLE_CLIENT_SECRET"),
+  google_scope: "profile email"

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -16,7 +16,7 @@ defmodule ElixirAuthGoogle do
   def get_baseurl_from_conn(%{host: h, port: p}) when h == "localhost" do
     "http://#{h}:#{p}"
   end
-  
+
   def get_baseurl_from_conn(%{host: h}) do
      "https://#{h}"
   end
@@ -90,9 +90,11 @@ defmodule ElixirAuthGoogle do
     body = Map.get(response, :body)
     if body == nil do
       {:error, :no_body}
-    else
-      Poison.decode(body) # should return an {:ok, map} tuple for consistecy?
-    end
+    else # make keys of map atoms for easier access in templates
+      {:ok, str_key_map} = Poison.decode(body)
+      atom_key_map = for {key, val} <- str_key_map, into: %{},
+        do: {String.to_atom(key), val}
+      {:ok, atom_key_map}
+    end # https://stackoverflow.com/questions/31990134
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "0.1.0"
+  @version "0.2.0"
 
   def project do
     [

--- a/test/elixir_auth_google_test.exs
+++ b/test/elixir_auth_google_test.exs
@@ -36,8 +36,7 @@ defmodule ElixirAuthGoogleTest do
       port: 4000
     }
     {:ok, res} = ElixirAuthGoogle.get_token("ok_code", conn)
-    IO.inspect res
-    # assert  == {:ok, %{access_token: "token1"}}
+    assert res == %{access_token: "token1"}
   end
 
   test "get_user_profile/1" do

--- a/test/elixir_auth_google_test.exs
+++ b/test/elixir_auth_google_test.exs
@@ -35,11 +35,13 @@ defmodule ElixirAuthGoogleTest do
       host: "localhost",
       port: 4000
     }
-    assert ElixirAuthGoogle.get_token("ok_code", conn) == {:ok, %{"access_token" => "token1"}}
+    {:ok, res} = ElixirAuthGoogle.get_token("ok_code", conn)
+    IO.inspect res
+    # assert  == {:ok, %{access_token: "token1"}}
   end
 
-  test "get user profile" do
-    assert ElixirAuthGoogle.get_user_profile("123") == {:ok, %{"name" => "dwyl"}}
+  test "get_user_profile/1" do
+    assert ElixirAuthGoogle.get_user_profile("123") == {:ok, %{name: "dwyl"}}
   end
 
   test "return error with incorrect token" do


### PR DESCRIPTION
Instead of forcing people to access keys of the map with `profile["name"]` they can use `profile.name`
+ [x] fixes #20 