### PR TITLE
Export TestDouble issue #35

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,4 +1,2 @@
 export GOOGLE_CLIENT_ID=YourAppsClientId.apps.googleusercontent.com
 export GOOGLE_CLIENT_SECRET=SuperSecret
-export SECRET_KEY_BASE=2PzB7PPnpuLsbWmWtXpGyI+kfSQSQ1zUW2Atz/+8PdZuSEJzHgzGnJWV35nTKRwx
-export ENCRYPTION_KEYS='nMdayQpR0aoasLaq1g94FLba+A+wB44JLko47sVQXMg=,L+ZVX8iheoqgqb22mUpATmMDsvVGtafoAeb0KN5uWf0='

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There were already _several_ available options
 for adding Google Auth to apps on
 [hex.pm/packages?search=google](https://hex.pm/packages?search=google) <br />
 that all added _far_ too many implementation steps (complexity)
-and had incomplete documentation (**`@doc false`**) and testing. <br />
+and had incomplete docs (**`@doc false`**) and tests. <br />
 e.g:
 [github.com/googleapis/elixir-google-api](https://github.com/googleapis/elixir-google-api)
 which is a

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,0 @@
-use Mix.Config
-
-# if Mix.env() == :test do
-#   config :elixir_auth_google, httpoison: ElixirAuthGoogle.HTTPoison.InMemory
-# end

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
-if Mix.env() == :test do
-  config :elixir_auth_google, httpoison: ElixirAuthGoogle.HTTPoison.InMemory
-end
+# if Mix.env() == :test do
+#   config :elixir_auth_google, httpoison: ElixirAuthGoogle.HTTPoison.InMemory
+# end

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -7,7 +7,7 @@ defmodule ElixirAuthGoogle do
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"
 
-  def inject() do
+  def inject_poison() do
     Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
   end
 
@@ -64,7 +64,7 @@ defmodule ElixirAuthGoogle do
   def get_token(code, conn) do
     env = Mix.env()
     IO.inspect(env, label: "env")
-    httpoison = inject()
+    httpoison = inject_poison()
     body = Poison.encode!(
       %{ client_id: System.get_env("GOOGLE_CLIENT_ID"),
          client_secret: System.get_env("GOOGLE_CLIENT_SECRET"),
@@ -88,7 +88,7 @@ defmodule ElixirAuthGoogle do
   """
   @spec get_user_profile(String.t) :: String.t
   def get_user_profile(token) do
-    httpoison = inject()
+    httpoison = inject_poison()
     "#{@google_user_profile}?access_token=#{token}"
     |> httpoison.get()
     |> parse_body_response()

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -3,7 +3,7 @@ defmodule ElixirAuthGoogle do
   Minimalist Google OAuth Authentication for Elixir Apps.
   Extensively tested, documented, maintained and in active use in production.
   """
-  @httpoison Application.get_env(:elixir_auth_google, :httpoison) || HTTPoison
+  @httpoison Mix.env() == :test && ElixirAuthGoogle.HTTPoison || HTTPoison
   @google_auth_url "https://accounts.google.com/o/oauth2/v2/auth?response_type=code"
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -7,6 +7,11 @@ defmodule ElixirAuthGoogle do
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"
 
+  @doc """
+  `inject_poison/0` injects a TestDouble of HTTPoison in Test
+  so that we don't have duplicate mock in consuming apps.
+  see: https://github.com/dwyl/elixir-auth-google/issues/35
+  """
   def inject_poison() do
     Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
   end
@@ -71,7 +76,6 @@ defmodule ElixirAuthGoogle do
     })
     inject_poison().post(@google_token_url, body)
     |> parse_body_response()
-    # |> IO.inspect(label: "get_token() response")
   end
 
   @doc """
@@ -84,11 +88,9 @@ defmodule ElixirAuthGoogle do
   """
   @spec get_user_profile(String.t) :: String.t
   def get_user_profile(token) do
-    httpoison = inject_poison()
     "#{@google_user_profile}?access_token=#{token}"
-    |> httpoison.get()
+    |> inject_poison().get()
     |> parse_body_response()
-    # |> IO.inspect(label: "get_user_profile() response")
   end
 
   @doc """

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -3,11 +3,13 @@ defmodule ElixirAuthGoogle do
   Minimalist Google OAuth Authentication for Elixir Apps.
   Extensively tested, documented, maintained and in active use in production.
   """
-  @httpoison Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
   @google_auth_url "https://accounts.google.com/o/oauth2/v2/auth?response_type=code"
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"
 
+  def inject() do
+    Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
+  end
 
   @doc """
   `get_baseurl_from_conn/1` derives the base URL from the conn struct
@@ -62,7 +64,7 @@ defmodule ElixirAuthGoogle do
   def get_token(code, conn) do
     env = Mix.env()
     IO.inspect(env, label: "env")
-    IO.inspect(@httpoison, label: "@httpoison")
+    httpoison = inject()
     body = Poison.encode!(
       %{ client_id: System.get_env("GOOGLE_CLIENT_ID"),
          client_secret: System.get_env("GOOGLE_CLIENT_SECRET"),
@@ -71,7 +73,7 @@ defmodule ElixirAuthGoogle do
          code: code
     })
     IO.inspect(body, label: "body")
-    @httpoison.post(@google_token_url, body)
+    httpoison.post(@google_token_url, body)
     |> parse_body_response()
     |> IO.inspect(label: "get_token() response")
   end
@@ -86,8 +88,9 @@ defmodule ElixirAuthGoogle do
   """
   @spec get_user_profile(String.t) :: String.t
   def get_user_profile(token) do
+    httpoison = inject()
     "#{@google_user_profile}?access_token=#{token}"
-    |> @httpoison.get()
+    |> httpoison.get()
     |> parse_body_response()
     |> IO.inspect(label: "get_user_profile() response")
   end

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -62,9 +62,6 @@ defmodule ElixirAuthGoogle do
   """
   @spec get_token(String.t, Map) :: String.t
   def get_token(code, conn) do
-    env = Mix.env()
-    IO.inspect(env, label: "env")
-    httpoison = inject_poison()
     body = Poison.encode!(
       %{ client_id: System.get_env("GOOGLE_CLIENT_ID"),
          client_secret: System.get_env("GOOGLE_CLIENT_SECRET"),
@@ -72,10 +69,9 @@ defmodule ElixirAuthGoogle do
          grant_type: "authorization_code",
          code: code
     })
-    IO.inspect(body, label: "body")
-    httpoison.post(@google_token_url, body)
+    inject_poison().post(@google_token_url, body)
     |> parse_body_response()
-    |> IO.inspect(label: "get_token() response")
+    # |> IO.inspect(label: "get_token() response")
   end
 
   @doc """
@@ -92,7 +88,7 @@ defmodule ElixirAuthGoogle do
     "#{@google_user_profile}?access_token=#{token}"
     |> httpoison.get()
     |> parse_body_response()
-    |> IO.inspect(label: "get_user_profile() response")
+    # |> IO.inspect(label: "get_user_profile() response")
   end
 
   @doc """

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -3,7 +3,7 @@ defmodule ElixirAuthGoogle do
   Minimalist Google OAuth Authentication for Elixir Apps.
   Extensively tested, documented, maintained and in active use in production.
   """
-  @httpoison Mix.env() == :test && ElixirAuthGoogle.HTTPoison || HTTPoison
+  @httpoison Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
   @google_auth_url "https://accounts.google.com/o/oauth2/v2/auth?response_type=code"
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -60,6 +60,9 @@ defmodule ElixirAuthGoogle do
   """
   @spec get_token(String.t, Map) :: String.t
   def get_token(code, conn) do
+    env = Mix.env()
+    IO.inspect(env, label: "env")
+    IO.inspect(@httpoison, label: "@httpoison")
     body = Poison.encode!(
       %{ client_id: System.get_env("GOOGLE_CLIENT_ID"),
          client_secret: System.get_env("GOOGLE_CLIENT_SECRET"),
@@ -67,9 +70,10 @@ defmodule ElixirAuthGoogle do
          grant_type: "authorization_code",
          code: code
     })
-
+    IO.inspect(body, label: "body")
     @httpoison.post(@google_token_url, body)
     |> parse_body_response()
+    |> IO.inspect(label: "get_token() response")
   end
 
   @doc """
@@ -85,6 +89,7 @@ defmodule ElixirAuthGoogle do
     "#{@google_user_profile}?access_token=#{token}"
     |> @httpoison.get()
     |> parse_body_response()
+    |> IO.inspect(label: "get_user_profile() response")
   end
 
   @doc """

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -18,7 +18,18 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   """
   def get(_url) do
     IO.inspect("HTTPoisonMock.get %{name: dwyl}")
-    {:ok, %{body: Poison.encode!(%{name: "dwyl"})}}
+    {:ok, %{body: Poison.encode!(
+     %{
+       email: "nelson@gmail.com",
+       email_verified: true,
+       family_name: "Correia",
+       given_name: "Nelson",
+       locale: "en",
+       name: "Nelson Correia",
+       picture: "https://lh3.googleusercontent.com/a-/AAuE7mApnYb260YC1JY7a",
+       sub: "940732358705212133793"
+     }
+    )}}
   end
 
   @doc """

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -9,16 +9,23 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   Obviously, don't invoke it from your App unless you want people to see fails.
   """
   def get("https://www.googleapis.com/oauth2/v3/userinfo?access_token=wrong_token") do
+    IO.inspect("HTTPoisonMock.get access_token=wrong_token")
     {:error, :bad_request}
   end
 
   @doc """
   get/1 using a dummy _url to test body decoding.
   """
-  def get(_url), do: {:ok, %{body: Poison.encode!(%{name: "dwyl"})}}
+  def get(_url) do
+    IO.inspect("HTTPoisonMock.get %{name: dwyl}")
+    {:ok, %{body: Poison.encode!(%{name: "dwyl"})}}
+  end
 
   @doc """
   post/2 passing in dummy _url & _body to test return of access_token.
   """
-  def post(_url, _body), do: {:ok, %{body: Poison.encode!(%{access_token: "token1"})}}
+  def post(_url, _body) do
+    IO.inspect("HTTPoisonMock.post %{ccess_token: token1}")
+    {:ok, %{body: Poison.encode!(%{access_token: "token1"})}}
+  end
 end

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -1,6 +1,6 @@
-defmodule ElixirAuthGoogle.HTTPoison do
+defmodule ElixirAuthGoogle.HTTPoisonMock do
   @moduledoc """
-  This is a test double for HTTPoison which returns a mock response.
+  This is a TestDouble for HTTPoison which returns a predictable response.
   Please see: https://github.com/dwyl/elixir-auth-google/issues/35
   """
 

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -9,7 +9,6 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   Obviously, don't invoke it from your App unless you want people to see fails.
   """
   def get("https://www.googleapis.com/oauth2/v3/userinfo?access_token=wrong_token") do
-    # IO.inspect("HTTPoisonMock.get access_token=wrong_token")
     {:error, :bad_request}
   end
 
@@ -17,7 +16,6 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   get/1 using a dummy _url to test body decoding.
   """
   def get(_url) do
-    # IO.inspect("HTTPoisonMock.get %{name: dwyl}")
     {:ok, %{body: Poison.encode!(
      %{
        email: "nelson@gmail.com",
@@ -36,7 +34,6 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   post/2 passing in dummy _url & _body to test return of access_token.
   """
   def post(_url, _body) do
-    # IO.inspect("HTTPoisonMock.post %{ccess_token: token1}")
     {:ok, %{body: Poison.encode!(%{access_token: "token1"})}}
   end
 end

--- a/lib/httpoison_mock.ex
+++ b/lib/httpoison_mock.ex
@@ -9,7 +9,7 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   Obviously, don't invoke it from your App unless you want people to see fails.
   """
   def get("https://www.googleapis.com/oauth2/v3/userinfo?access_token=wrong_token") do
-    IO.inspect("HTTPoisonMock.get access_token=wrong_token")
+    # IO.inspect("HTTPoisonMock.get access_token=wrong_token")
     {:error, :bad_request}
   end
 
@@ -17,7 +17,7 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   get/1 using a dummy _url to test body decoding.
   """
   def get(_url) do
-    IO.inspect("HTTPoisonMock.get %{name: dwyl}")
+    # IO.inspect("HTTPoisonMock.get %{name: dwyl}")
     {:ok, %{body: Poison.encode!(
      %{
        email: "nelson@gmail.com",
@@ -36,7 +36,7 @@ defmodule ElixirAuthGoogle.HTTPoisonMock do
   post/2 passing in dummy _url & _body to test return of access_token.
   """
   def post(_url, _body) do
-    IO.inspect("HTTPoisonMock.post %{ccess_token: token1}")
+    # IO.inspect("HTTPoisonMock.post %{ccess_token: token1}")
     {:ok, %{body: Poison.encode!(%{access_token: "token1"})}}
   end
 end

--- a/lib/testdouble.ex
+++ b/lib/testdouble.ex
@@ -1,10 +1,7 @@
-defmodule ElixirAuthGoogle.HTTPoison.InMemory do
+defmodule ElixirAuthGoogle.HTTPoison do
   @moduledoc """
-  In-memory storage for data while it's being processed.
-  Because we are mocking the api requests in ElixirAuthGithub.HTTPoison.InMemory
-  we have a separate module to delegate the functions we use to the actual
-  HTTPoison module, so that's all we do here.
-  Note: if you have a suggestion of a better way to do this, please share!
+  This is a test double for HTTPoison which returns a mock response.
+  Please see: https://github.com/dwyl/elixir-auth-google/issues/35
   """
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule ElixirAuthGoogle.MixProject do
       maintainers: ["dwyl"],
       licenses: ["GNU GPL v2.0"],
       links: %{github: "https://github.com/dwyl/elixir-auth-google"},
-      files: ~w(lib LICENSE mix.exs README.md .formatter.exs config/config.exs)
+      files: ~w(lib LICENSE mix.exs README.md .formatter.exs)
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.1.4"
+  @version "1.1.5"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.1.2"
+  @version "1.1.3"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.1.3"
+  @version "1.1.4"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.1.5"
+  @version "1.2.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.1.0"
+  @version "1.1.1"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.1.1"
+  @version "1.1.2"
 
   def project do
     [

--- a/test/elixir_auth_google_test.exs
+++ b/test/elixir_auth_google_test.exs
@@ -34,7 +34,11 @@ defmodule ElixirAuthGoogleTest do
       host: "localhost",
       port: 4000
     }
-    assert ElixirAuthGoogle.generate_oauth_url(conn, "state1") == "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=&scope=profile email&redirect_uri=http://localhost:4000/auth/google/callback&state=state1"
+    url = ElixirAuthGoogle.generate_oauth_url(conn, "state1")
+    id = System.get_env("GOOGLE_CLIENT_ID")
+    expected = "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=" <> id
+      <> "&scope=profile email&redirect_uri=http://localhost:4000/auth/google/callback&state=state1"
+    assert url == expected
   end
 
   test "get Google token" do

--- a/test/elixir_auth_google_test.exs
+++ b/test/elixir_auth_google_test.exs
@@ -51,7 +51,17 @@ defmodule ElixirAuthGoogleTest do
   end
 
   test "get_user_profile/1" do
-    assert ElixirAuthGoogle.get_user_profile("123") == {:ok, %{name: "dwyl"}}
+    res = %{
+      email: "nelson@gmail.com",
+      email_verified: true,
+      family_name: "Correia",
+      given_name: "Nelson",
+      locale: "en",
+      name: "Nelson Correia",
+      picture: "https://lh3.googleusercontent.com/a-/AAuE7mApnYb260YC1JY7a",
+      sub: "940732358705212133793"
+    }
+    assert ElixirAuthGoogle.get_user_profile("123") == {:ok, res}
   end
 
   test "return error with incorrect token" do


### PR DESCRIPTION
As discussed in #35 I'm not a fan of having to _duplicate_ Mock versions of the OAuth functions.
This PR introduces a _transparent_ TestDouble which means the **`Auth`** App (_and any other people_) using this module no longer need to _think_ about Mocking the requests. 
I think this will greatly improve the UX and our maintainability.

+ [x] Export HTTPoisonTest (`TestDouble`) for #35 
+ [x] Publish new version of package: https://hex.pm/packages/elixir_auth_google/1.2.0