### PR TITLE
Determine HTTPoison module at compile time

### DIFF
--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -7,14 +7,14 @@ defmodule ElixirAuthGoogle do
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"
 
+  @httpoison Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
+
   @doc """
   `inject_poison/0` injects a TestDouble of HTTPoison in Test
   so that we don't have duplicate mock in consuming apps.
   see: https://github.com/dwyl/elixir-auth-google/issues/35
   """
-  def inject_poison() do
-    Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
-  end
+  def inject_poison(), do: @httpoison
 
   @doc """
   `get_baseurl_from_conn/1` derives the base URL from the conn struct


### PR DESCRIPTION
Follow up from #37.

Moving this check to a module attribute means it will be executed at compile time, which removes the need for adding mix to `:extra_applications` in `mix.exs`.

All tests pass, and the module is determined correctly based on env:

```elixir
elixir-auth-google $ mix run -e "IO.inspect ElixirAuthGoogle.inject_poison()"
HTTPoison
elixir-auth-google $ MIX_ENV=test mix run -e "IO.inspect ElixirAuthGoogle.inject_poison()"
ElixirAuthGoogle.HTTPoisonMock
```

