### PR TITLE
use Application.get_env instead of Mix.env

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,6 +2,8 @@ use Mix.Config
 
 config :elixir_auth_google,
   client_id: "631770888008-6n0oruvsm16kbkqg6u76p5cv5kfkcekt.apps.googleusercontent.com",
-  client_secret: "MHxv6-RGF5nheXnxh1b0LNDq"
+  client_secret: "MHxv6-RGF5nheXnxh1b0LNDq",
+  httpoison_mock: true
+
 
 System.put_env("GOOGLE_CLIENT_ID", "631770888008-6n0oruvsm16kbkqg6u76p5cv5kfkcekt.apps.googleusercontent.com")

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -7,7 +7,7 @@ defmodule ElixirAuthGoogle do
   @google_token_url "https://oauth2.googleapis.com/token"
   @google_user_profile "https://www.googleapis.com/oauth2/v3/userinfo"
 
-  @httpoison Mix.env() == :test && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
+  @httpoison Application.get_env(:elixir_auth_google, :httpoison_mock) && ElixirAuthGoogle.HTTPoisonMock || HTTPoison
 
   @doc """
   `inject_poison/0` injects a TestDouble of HTTPoison in Test

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.6.0"
+  @version "1.6.1"
 
   def project do
     [


### PR DESCRIPTION
ref: https://github.com/dwyl/auth/pull/147#issuecomment-939991757
This allow applications using this library to use the mock functions instead of using Google APIs.
This also resolve the issue of having Mix.env being always :prod when the library is compiled hence failing tests on the main application.