### PR TITLE
Adds missing typespec to generate_oauth_url/1

### DIFF
--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -78,6 +78,7 @@ defmodule ElixirAuthGoogle do
   This is the URL you need to use for your "Login with Google" button.
   See step 5 of the instructions.
   """
+  @spec generate_oauth_url(binary()) :: String.t()
   def generate_oauth_url(url) when is_binary(url) do
     query = %{
       client_id: google_client_id(),

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -78,7 +78,7 @@ defmodule ElixirAuthGoogle do
   This is the URL you need to use for your "Login with Google" button.
   See step 5 of the instructions.
   """
-  @spec generate_oauth_url(binary()) :: String.t()
+  @spec generate_oauth_url(String.t()) :: String.t()
   def generate_oauth_url(url) when is_binary(url) do
     query = %{
       client_id: google_client_id(),


### PR DESCRIPTION
This pull request addresses an important update for the `generate_oauth_url/1` function by adding a missing typespec. The addition of this typespec ensures compliance with Dialyzer contracts, which helps improve code reliability and maintainability.

Fixes https://github.com/dwyl/elixir-auth-google/issues/96