### PR TITLE
Port Avaiability. elixir_auth_google.ex

### DIFF
--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -25,10 +25,15 @@ defmodule ElixirAuthGoogle do
   @doc """
   `get_baseurl_from_conn/1` derives the base URL from the conn struct
   """
-  @spec get_baseurl_from_conn(conn) :: String.t()
-  def get_baseurl_from_conn(%{host: h, port: p, scheme: s}) when p != 80 || p !=443 do
-    "#{Atom.to_string(s)}://#{h}:#{p}"
+   @spec get_baseurl_from_conn(conn) :: String.t()
+  def get_baseurl_from_conn(%{host: h, port: p, scheme: s}) do
+    if p != 80 do
+     "#{Atom.to_string(s)}://#{h}"
+       else
+     "#{Atom.to_string(s)}://#{h}:#{p}"
+    end
   end
+
 
   def get_baseurl_from_conn(%{host: h, scheme: s}) do
     "#{Atom.to_string(s)}://#{h}"

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -26,7 +26,7 @@ defmodule ElixirAuthGoogle do
   `get_baseurl_from_conn/1` derives the base URL from the conn struct
   """
   @spec get_baseurl_from_conn(conn) :: String.t()
-  def get_baseurl_from_conn(%{host: h, port: p, scheme: s}) when p != 80 do
+  def get_baseurl_from_conn(%{host: h, port: p, scheme: s}) when p != 80 || !=443 do
     "#{Atom.to_string(s)}://#{h}:#{p}"
   end
 

--- a/lib/elixir_auth_google.ex
+++ b/lib/elixir_auth_google.ex
@@ -26,7 +26,7 @@ defmodule ElixirAuthGoogle do
   `get_baseurl_from_conn/1` derives the base URL from the conn struct
   """
   @spec get_baseurl_from_conn(conn) :: String.t()
-  def get_baseurl_from_conn(%{host: h, port: p, scheme: s}) when p != 80 || !=443 do
+  def get_baseurl_from_conn(%{host: h, port: p, scheme: s}) when p != 80 || p !=443 do
     "#{Atom.to_string(s)}://#{h}:#{p}"
   end
 


### PR DESCRIPTION
Case the user starts a project in port 4001 the "baseurl" it will be as https://example.com and not https:example.com:4001.