### PR TITLE
PR: Bump version 1.6.10 -> 1.6.11 to release recent updates #165 #164

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirAuthGoogle.MixProject do
   use Mix.Project
 
   @description "Minimalist Google OAuth Authentication for Elixir Apps"
-  @version "1.6.10"
+  @version "1.6.11"
 
   def project do
     [


### PR DESCRIPTION
Micro PR just to bump the version and release `1.6.11` with many deps updates but no code changes. 